### PR TITLE
feat: add MCP settings section with autoAuth and idleTimeout

### DIFF
--- a/.pi/agent/mcp.json
+++ b/.pi/agent/mcp.json
@@ -10,11 +10,13 @@
     "context7": {
       "url": "https://mcp.context7.com/mcp",
       "headers": {
-        "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
       }
     },
     "github": {
       "command": "npx",
+      "auth": "bearer",
+      "bearerTokenEnv": "GITHUB_TOKEN",
       "args": [
         "-y",
         "@modelcontextprotocol/server-github"

--- a/.pi/agent/mcp.json
+++ b/.pi/agent/mcp.json
@@ -1,4 +1,8 @@
 {
+  "settings": {
+    "autoAuth": true,
+    "idleTimeout": 15
+  },
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",


### PR DESCRIPTION
## Changes

- Add `settings` section to `mcp.json`
- Enable `autoAuth: true` for automatic OAuth handling
- Set `idleTimeout: 15` (minutes) for better resource management

## Rationale

The `autoAuth` setting automatically handles OAuth flows when servers need authentication.

The `idleTimeout` of 15 minutes disconnects idle MCP servers to conserve resources.