### PR TITLE
chore: add dexto to skill lock and update default model

### DIFF
--- a/.agents/.skill-lock.json
+++ b/.agents/.skill-lock.json
@@ -66,6 +66,7 @@
     "codex",
     "cursor",
     "deepagents",
+    "dexto",
     "firebender",
     "gemini-cli",
     "github-copilot",

--- a/.pi/agent/settings.json
+++ b/.pi/agent/settings.json
@@ -1,7 +1,7 @@
 {
   "lastChangelogVersion": "0.73.0",
   "defaultProvider": "opencode-go",
-  "defaultModel": "mimo-v2.5",
+  "defaultModel": "kimi-k2.6",
   "defaultThinkingLevel": "high",
   "enableInstallTelemetry": false,
   "quietStartup": true,


### PR DESCRIPTION
- Added "dexto" entry to .agents/.skill-lock.json.\n- Updated defaultModel from "mimo-v2.5" to "kimi-k2.6" in .pi/agent/settings.json.